### PR TITLE
Downgrade SDK to support VS19 installs

### DIFF
--- a/src/FantomasVs.Shared/OuptutLogging.cs
+++ b/src/FantomasVs.Shared/OuptutLogging.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using OutputPane = Microsoft.VisualStudio.Shell.Interop.IVsOutputWindowPane;
 using System.Diagnostics;
 using System.Threading;
+using Task = System.Threading.Tasks.Task;
 
 namespace FantomasVs
 {

--- a/src/FantomasVs.VS2019/FantomasVs.VS2019.csproj
+++ b/src/FantomasVs.VS2019/FantomasVs.VS2019.csproj
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.35">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">

--- a/src/FantomasVs.VS2019/FantomasVs.VS2019.csproj
+++ b/src/FantomasVs.VS2019/FantomasVs.VS2019.csproj
@@ -81,7 +81,7 @@
     <PackageReference Include="FSharp.Core">
       <Version>5.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038">

--- a/src/FantomasVs.VS2019/source.extension.vsixmanifest
+++ b/src/FantomasVs.VS2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="FantomasVs.ef00bfc2-a899-45fc-aae8-afecf8673aaf" Version="1.0.1" Language="en-US" Publisher="Asti" />
+        <Identity Id="FantomasVs.ef00bfc2-a899-45fc-aae8-afecf8673aaf" Version="1.0.2" Language="en-US" Publisher="Asti" />
         <DisplayName>F# Formatting</DisplayName>
         <Description xml:space="preserve">F# source code formatting using Fantomas. </Description>
         <MoreInfo>https://github.com/deviousasti/fsharp-formatting-for-vs</MoreInfo>


### PR DESCRIPTION
Targeting a lower version of SDK, while using a newer version of build tools.
Moving to SDK 16.0 should mean even older VS installs are supported.
Fixes #26